### PR TITLE
remove type: module from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "test": "jest"
   },
   "sideEffects": false,
-  "type": "module",
   "types": "dist/index.d.ts",
   "version": "2.3.25"
 }


### PR DESCRIPTION
`type: module` defines a module as being fully compliant to the [NodeJS ESM](https://nodejs.org/api/esm.html) spec.  Removing for now since a key aspect of the esm spec [requires adding file extensions to all imports](https://nodejs.org/api/esm.html#mandatory-file-extensions).  As of right now, Typescript also has to be [upgraded](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/) to nightly builds and use a different file extension (.mts | .cts) to support transpiling to esm.