### PR TITLE
Send errors and warning to Rollbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ bin
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+
+.idea

--- a/src/shared/Log.spec.ts
+++ b/src/shared/Log.spec.ts
@@ -5,4 +5,37 @@ describe('Log', () => {
     const log = new Log({ devMode: false })
     expect(log).toBeDefined()
   })
+  test('rollbar error methods not to be called when in dev', () => {
+    jest.spyOn(global.console, 'error').mockImplementation()
+    const log = new Log({ devMode: true, rollbarToken: 'mock' })
+    const errorSpy = jest.spyOn((log as any).rollbar, 'error')
+    log.error(['ERROR'])
+    //@ts-ignore
+    expect(errorSpy).toBeCalledTimes(0)
+  })
+  test('rollbar error methods to be called when not in dev', () => {
+    jest.spyOn(global.console, 'error').mockImplementation()
+    const log = new Log({ devMode: false, rollbarToken: 'mock' })
+    const errorSpy = jest.spyOn((log as any).rollbar, 'error')
+    log.error(['ERROR'])
+    //@ts-ignore
+    expect(errorSpy).toHaveBeenCalled()
+  })
+  test('rollbar warn methods not to be called when in dev', () => {
+    jest.spyOn(global.console, 'warn').mockImplementation()
+    const log = new Log({ devMode: true, rollbarToken: 'mock' })
+    const warnSpy = jest.spyOn((log as any).rollbar, 'warn')
+    log.warn(['WARNING'])
+    //@ts-ignore
+    expect(warnSpy).toBeCalledTimes(0)
+  })
+  test('rollbar warn methods to be called when not in dev', () => {
+    jest.spyOn(global.console, 'warn').mockImplementation()
+    const log = new Log({ devMode: false, rollbarToken: 'mock' })
+    const warnSpy = jest.spyOn((log as any).rollbar, 'error')
+    log.error(['WARNING'])
+    //@ts-ignore
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
 })

--- a/src/shared/Log.ts
+++ b/src/shared/Log.ts
@@ -42,7 +42,7 @@ class Log {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public error(...params: any[]) {
     console.error(params)
-    if (this.devMode) {
+    if (!this.devMode) {
       this.rollbar?.error(params)
     }
   }
@@ -50,28 +50,28 @@ class Log {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public warn(...params: any[]) {
     console.warn(params)
-    if (this.devMode) {
+    if (!this.devMode) {
       this.rollbar?.warn(params)
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public info(...params: any[]) {
-    if (this.devMode) {
+    if (!this.devMode) {
       console.info(params)
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public debug(...params: any[]) {
-    if (this.devMode) {
+    if (!this.devMode) {
       console.debug(params)
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public log(...params: any[]) {
-    if (this.devMode) {
+    if (!this.devMode) {
       console.log(params)
     }
   }

--- a/src/shared/Log.ts
+++ b/src/shared/Log.ts
@@ -57,21 +57,21 @@ class Log {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public info(...params: any[]) {
-    if (!this.devMode) {
+    if (this.devMode) {
       console.info(params)
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public debug(...params: any[]) {
-    if (!this.devMode) {
+    if (this.devMode) {
       console.debug(params)
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public log(...params: any[]) {
-    if (!this.devMode) {
+    if (this.devMode) {
       console.log(params)
     }
   }


### PR DESCRIPTION
When not in development, send error and warning to Rollbar.
When in development allow info, debug and log.